### PR TITLE
feat: run shouldNotFilter before checking jwtToken

### DIFF
--- a/src/main/java/com/codeit/moim/web/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/codeit/moim/web/filter/JwtAuthenticationFilter.java
@@ -27,6 +27,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private static final int UNAUTHORIZED = 401;
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        if (shouldNotFilter(request)) {
+            log.info("Skipping JWT filter for path: " + request.getRequestURI());
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         String jwtToken = jwtTokenProvider.resolveToken(request);
 
         try{


### PR DESCRIPTION
## #️⃣ Issue ticket number and link

> ex) #issue number

- close #29 

## ✔️Type of change
- [ ] 👍 New feature
- [ ] 🐛 Bug fix
- [ ] 📕 Docs update
- [ ] 👩🏻‍💻 Code Refactor

## 📝Description

- Ensure JWT filter does shouldNotFilter method before checking jwt is null


### 📸 Screenshots(if appropriate)

## 💬Required review(if appropriate)

> Add if a specific review is required from the reviewer <br>
> ex) Any better ideas for method name XXX?