### PR TITLE
refactor: get my comments to my page controller

### DIFF
--- a/src/main/java/com/codeit/moim/service/comment/CommentService.java
+++ b/src/main/java/com/codeit/moim/service/comment/CommentService.java
@@ -22,5 +22,4 @@ public interface CommentService {
 
     Slice<ReadMeetingCommentResponse> getMeetingComments(int meetingId, ReadMeetingCommentRequest request);
 
-    Slice<ReadMyCommentResponse> getMyComments(int userId, ReadMyCommentRequest request);
 }

--- a/src/main/java/com/codeit/moim/service/comment/impl/CommentServiceImpl.java
+++ b/src/main/java/com/codeit/moim/service/comment/impl/CommentServiceImpl.java
@@ -144,29 +144,7 @@ public class CommentServiceImpl implements CommentService {
         return new CustomSlice<>(commentResponses, pageable, comments.hasNext(), nextCursor);
     }
 
-    @Override
-    public Slice<ReadMyCommentResponse> getMyComments(int userId, ReadMyCommentRequest request) {
-        int pageSize = request.size();
-        Pageable pageable = PageRequest.of(0, pageSize);
 
-        Slice<Comment> comments;
-        if(Objects.isNull(request.lastCommentId()) || request.lastCommentId() <=0 ) {
-            comments = commentRepository.findByUser_userIdOrderByCommentIdDesc(userId, pageable);
-        }else{
-            comments = commentRepository.findByUser_UserIdAndCommentIdLessThanOrderByCommentIdDesc(userId, request.lastCommentId(), pageable);
-        }
-
-        List<ReadMyCommentResponse> commentResponses = comments.stream()
-                .map(comment ->
-                                ReadMyCommentResponse.fromEntity(comment, comment.getMeeting())
-                        ).collect(Collectors.toList());
-
-        Integer nextCursor = comments.hasNext()
-                ? comments.getContent().get(comments.getContent().size() -1).getCommentId()
-                : null;
-
-        return new CustomSlice<>(commentResponses, pageable, comments.hasNext(), nextCursor);
-    }
 
     private User getUser(int userId){
         User user = userRepository.findById(userId)

--- a/src/main/java/com/codeit/moim/service/mypage/MyPageService.java
+++ b/src/main/java/com/codeit/moim/service/mypage/MyPageService.java
@@ -1,8 +1,11 @@
 package com.codeit.moim.service.mypage;
 
+import com.codeit.moim.web.dto.request.comment.ReadMyCommentRequest;
 import com.codeit.moim.web.dto.request.mypage.*;
+import com.codeit.moim.web.dto.response.comment.ReadMyCommentResponse;
 import com.codeit.moim.web.dto.response.member.CreateMemberResponse;
 import com.codeit.moim.web.dto.response.mypage.*;
+import org.springframework.data.domain.Slice;
 
 public interface MyPageService {
     UpdateProfilePicResponse updateProfilePic(int userId, UpdateProfilePicRequest request);
@@ -16,4 +19,7 @@ public interface MyPageService {
     UpdateUserResponse updateUserInfo(int userId, UpdateUserRequest request);
 
     UpdatePasswordResponse updateUserPassword(int userId, UpdatePasswordRequest request);
+
+    Slice<ReadMyCommentResponse> getMyComments(int userId, ReadMyCommentRequest request);
+
 }

--- a/src/main/java/com/codeit/moim/service/mypage/impl/MyPageServiceImpl.java
+++ b/src/main/java/com/codeit/moim/service/mypage/impl/MyPageServiceImpl.java
@@ -3,21 +3,21 @@ package com.codeit.moim.service.mypage.impl;
 import com.codeit.moim.common.exception.auth.PasswordInvlaidException;
 import com.codeit.moim.common.exception.auth.UserNotFoundException;
 import com.codeit.moim.common.exception.payload.ErrorStatus;
-import com.codeit.moim.domain.Contact;
-import com.codeit.moim.domain.Skill;
-import com.codeit.moim.domain.User;
-import com.codeit.moim.domain.UserSkill;
-import com.codeit.moim.repository.ContactRepository;
-import com.codeit.moim.repository.SkillRepository;
-import com.codeit.moim.repository.UserRepository;
-import com.codeit.moim.repository.UserSkillRepository;
+import com.codeit.moim.domain.*;
+import com.codeit.moim.repository.*;
 import com.codeit.moim.service.mypage.MyPageService;
 import com.codeit.moim.service.storage.StorageService;
 import com.codeit.moim.service.user.impl.UserServiceImpl;
+import com.codeit.moim.web.dto.request.comment.ReadMyCommentRequest;
 import com.codeit.moim.web.dto.request.mypage.*;
+import com.codeit.moim.web.dto.response.comment.ReadMyCommentResponse;
 import com.codeit.moim.web.dto.response.member.CreateMemberResponse;
 import com.codeit.moim.web.dto.response.mypage.*;
+import com.codeit.moim.web.dto.response.slice.CustomSlice;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +35,7 @@ public class MyPageServiceImpl implements MyPageService {
     private final ContactRepository contactRepository;
     private final UserSkillRepository userSkillRepository;
     private final SkillRepository skillRepository;
+    private final CommentRepository commentRepository;
     private final UserServiceImpl userServiceImpl;
     private final PasswordEncoder passwordEncoder;
 
@@ -119,6 +120,30 @@ public class MyPageServiceImpl implements MyPageService {
         userRepository.save(user);
 
         return new UpdatePasswordResponse(userId);
+    }
+
+    @Override
+    public Slice<ReadMyCommentResponse> getMyComments(int userId, ReadMyCommentRequest request) {
+        int pageSize = request.size();
+        Pageable pageable = PageRequest.of(0, pageSize);
+
+        Slice<Comment> comments;
+        if(Objects.isNull(request.lastCommentId()) || request.lastCommentId() <=0 ) {
+            comments = commentRepository.findByUser_userIdOrderByCommentIdDesc(userId, pageable);
+        }else{
+            comments = commentRepository.findByUser_UserIdAndCommentIdLessThanOrderByCommentIdDesc(userId, request.lastCommentId(), pageable);
+        }
+
+        List<ReadMyCommentResponse> commentResponses = comments.stream()
+                .map(comment ->
+                        ReadMyCommentResponse.fromEntity(comment, comment.getMeeting())
+                ).collect(Collectors.toList());
+
+        Integer nextCursor = comments.hasNext()
+                ? comments.getContent().get(comments.getContent().size() -1).getCommentId()
+                : null;
+
+        return new CustomSlice<>(commentResponses, pageable, comments.hasNext(), nextCursor);
     }
 
     private User getUser(int userId){

--- a/src/main/java/com/codeit/moim/web/controller/CommentController.java
+++ b/src/main/java/com/codeit/moim/web/controller/CommentController.java
@@ -119,19 +119,5 @@ public class CommentController {
         return Response.ok(commentService.getMeetingComments(meetingId, request));
     }
 
-    @Operation(
-            summary = "Get my comments",
-            description = "Get my comment, infinite scroll applied with min size 3"
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Get success")
-    })
-    @GetMapping("/my")
-    public Response<Slice<ReadMyCommentResponse>> readMyComemnts(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @Valid @ModelAttribute ReadMyCommentRequest request
-            ) {
-        int userId = userDetails.getUserId();
-        return Response.ok(commentService.getMyComments(userId, request));
-    }
+
 }

--- a/src/main/java/com/codeit/moim/web/controller/MyPageController.java
+++ b/src/main/java/com/codeit/moim/web/controller/MyPageController.java
@@ -2,14 +2,18 @@ package com.codeit.moim.web.controller;
 
 import com.codeit.moim.repository.CustomUserDetails;
 import com.codeit.moim.service.mypage.MyPageService;
+import com.codeit.moim.web.dto.request.comment.ReadMyCommentRequest;
 import com.codeit.moim.web.dto.request.mypage.*;
 import com.codeit.moim.web.dto.response.Response;
+import com.codeit.moim.web.dto.response.comment.ReadMyCommentResponse;
 import com.codeit.moim.web.dto.response.mypage.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.sql.Update;
+import org.springframework.data.domain.Slice;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -113,6 +117,22 @@ public class MyPageController {
     ){
         int userId = userDetails.getUserId();
         return Response.ok(myPageService.updateUserPassword(userId, request));
+    }
+
+    @Operation(
+            summary = "Get my comments",
+            description = "Get my comment, infinite scroll applied with min size 3"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Get success")
+    })
+    @GetMapping("/comments")
+    public Response<Slice<ReadMyCommentResponse>> readMyComemnts(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @ModelAttribute ReadMyCommentRequest request
+    ) {
+        int userId = userDetails.getUserId();
+        return Response.ok(myPageService.getMyComments(userId, request));
     }
 
 }


### PR DESCRIPTION
## #️⃣ Issue ticket number and link

> ex) #issue number

- close #119

## ✔️Type of change
- [ ] 👍 New feature
- [x] 🐛 Bug fix
- [ ] 📕 Docs update
- [ ] 👩🏻‍💻 Code Refactor

## 📝Description

> Change GET my comments to my page controller
- in comments controller, all other GET apis do not require token
- excluded in jwt filter, permitted in security config
- thus, the only GET request that requires token also could not recognize token in comment controller
- thus, moved to my page controller



### 📸 Screenshots(if appropriate)

## 💬Required review(if appropriate)

> Add if a specific review is required from the reviewer <br>
> ex) Any better ideas for method name XXX?