### PR TITLE
refactor: update isPublic field to opposite of current status

### DIFF
--- a/src/main/java/com/codeit/moim/domain/Meeting.java
+++ b/src/main/java/com/codeit/moim/domain/Meeting.java
@@ -105,9 +105,13 @@ public class Meeting {
         else this.memberCount--;
     }
 
-    public void updateIsPublic(){
+    public void updateIsPublicToFalse(){
         this.isPublic = false;
     }
+    public void updateIsPublicToTrue(){
+        this.isPublic = true;
+    }
+
 
     public void increaseLikesCount() {
         this.likesCount++;

--- a/src/main/java/com/codeit/moim/service/mymeeting/impl/MyMeetingServiceImpl.java
+++ b/src/main/java/com/codeit/moim/service/mymeeting/impl/MyMeetingServiceImpl.java
@@ -139,14 +139,17 @@ public class MyMeetingServiceImpl implements MyMeetingService {
     @Override
     public UpdateMeetingIsPublicResponse updateIsPublic(int userId, int meetingId) {
         Meeting meeting = getMeeting(meetingId);
-        if(validateMeetingManager(userId, meeting)) throw new MeetingAccessDeniedException(String.valueOf(meeting.getMeetingId()));
+        if(!validateMeetingManager(userId, meeting)) throw new MeetingAccessDeniedException(String.valueOf(meeting.getMeetingId()));
         if(meeting.isPublic()){
-            meeting.updateIsPublic();
-            meetingRepository.save(meeting);
+            meeting.updateIsPublicToFalse();
+            Meeting savedMeeting = meetingRepository.save(meeting);
 
-            return new UpdateMeetingIsPublicResponse(meetingId);
+            return UpdateMeetingIsPublicResponse.fromEntity(savedMeeting);
         }else{
-            throw new AlreadyIsPublicException(ErrorStatus.toErrorStatus("This meeting is already isPublic = false", BAD_REQUEST));
+            meeting.updateIsPublicToTrue();
+            Meeting savedMeeting = meetingRepository.save(meeting);
+
+            return UpdateMeetingIsPublicResponse.fromEntity(savedMeeting);
         }
 
     }

--- a/src/main/java/com/codeit/moim/web/dto/response/mymeeting/UpdateMeetingIsPublicResponse.java
+++ b/src/main/java/com/codeit/moim/web/dto/response/mymeeting/UpdateMeetingIsPublicResponse.java
@@ -1,6 +1,17 @@
 package com.codeit.moim.web.dto.response.mymeeting;
 
+import com.codeit.moim.domain.Meeting;
+import lombok.Builder;
+
+@Builder
 public record UpdateMeetingIsPublicResponse (
-        int meetingId
+        int meetingId,
+        boolean isPublic
 ){
+    public static UpdateMeetingIsPublicResponse fromEntity(Meeting meeting){
+        return UpdateMeetingIsPublicResponse.builder()
+                .meetingId(meeting.getMeetingId())
+                .isPublic(meeting.isPublic())
+                .build();
+    }
 }


### PR DESCRIPTION
## #️⃣ Issue ticket number and link

> ex) #issue number

- close #131

## ✔️Type of change
- [x] 👍 New feature
- [x] 🐛 Bug fix
- [ ] 📕 Docs update
- [ ] 👩🏻‍💻 Code Refactor

## 📝Description

- fix 403 error of validating meeting manager
- check current status isPublic of meeting
- update to opposite status
- response with updated isPublic field

### 📸 Screenshots(if appropriate)

## 💬Required review(if appropriate)

> Add if a specific review is required from the reviewer <br>
> ex) Any better ideas for method name XXX?