### PR TITLE
Modify exception response to ResponseEntity<Response<ErrorResponse>>

### DIFF
--- a/src/main/java/com/codeit/moim/common/handler/GlobalRestControllerAdvice.java
+++ b/src/main/java/com/codeit/moim/common/handler/GlobalRestControllerAdvice.java
@@ -22,7 +22,7 @@ public class GlobalRestControllerAdvice {
      * @return 해당 HTTP 상태 코드와 오류 정보를 반환
      */
     @ExceptionHandler(ApplicationException.class)
-    public Response<ErrorResponse> handleApplicationException(ApplicationException e) {
+    public ResponseEntity<Response<ErrorResponse>> handleApplicationException(ApplicationException e) {
         ErrorStatus errorStatus = e.getErrorStatus();
 
 
@@ -43,7 +43,9 @@ public class GlobalRestControllerAdvice {
             errorResponse = new ErrorResponse(errorStatus.message());
         }
 
-        return new Response<>(errorStatus.statusCode(), errorResponse);
+        return ResponseEntity
+                .status(errorStatus.statusCode())
+                .body(new Response<>(errorStatus.statusCode(), errorResponse));
     }
 
     @ExceptionHandler(ServletException.class)

--- a/src/main/java/com/codeit/moim/service/meeting/impl/MeetingServiceImpl.java
+++ b/src/main/java/com/codeit/moim/service/meeting/impl/MeetingServiceImpl.java
@@ -165,6 +165,7 @@ public class MeetingServiceImpl implements MeetingService {
     @Override
     public ReadMeetingDetailResponse findMeetingDetail(int meetingId) {
         Meeting meeting = meetingRepository.findByIdWithUser(meetingId);
+        if( meeting == null ) throw new MeetingNotFoundException("MeetingId: " + meetingId);
 
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String email = (authentication instanceof AnonymousAuthenticationToken) ? "no user" : authentication.getName();

--- a/src/main/java/com/codeit/moim/service/mymeeting/impl/MyMeetingServiceImpl.java
+++ b/src/main/java/com/codeit/moim/service/mymeeting/impl/MyMeetingServiceImpl.java
@@ -244,6 +244,7 @@ public class MyMeetingServiceImpl implements MyMeetingService {
     @Transactional
     public UpdateMeetingResponse updateMeetingInfo(int userId, int meetingId, UpdateMeetingRequest request) {
         Meeting meeting = meetingRepository.findByIdWithUser(meetingId);
+        if( meeting == null ) throw new MeetingNotFoundException("MeetingId: " + meetingId);
         if(!validateMeetingManager(userId, meeting)) throw new MeetingAccessDeniedException("Only meeting manager can update meeting detail. UserId: "+ userId);
 
         Category category = null;


### PR DESCRIPTION
## #️⃣ Issue ticket number and link

> ex) #issue number

- close #150 

## ✔️Type of change
- [ ] 👍 New feature
- [ ] 🐛 Bug fix
- [ ] 📕 Docs update
- [x] 👩🏻‍💻 Code Refactor

## 📝Description

> Modify exception response from Response<ErrorResponse> to  ResponseEntity<Response<ErrorResponse>>

❓ WHY?
- only with Response<ErrorResponse>, the HTTP status code will always be ok(200)
- with response in responseEntity, can respond with error code. 

- also throw error when meetingId is not found


### 📸 Screenshots(if appropriate)

## 💬Required review(if appropriate)

> Add if a specific review is required from the reviewer <br>
> ex) Any better ideas for method name XXX?